### PR TITLE
fix(maps): replace scheme relative basemap URL's

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -13,8 +13,14 @@
           "streetmap": {
             "url": "https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}"
           },
+          "streetmap-4326": {
+            "url": "https://services.arcgisonline.com/ArcGIS/rest/services/ESRI_StreetMap_World_2D/MapServer/tile/{z}/{y}/{x}"
+          },
           "worldimagery": {
             "url": "https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+          },
+          "worldimagery-4326": {
+            "url": "https://wi.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
           }
         }
       }


### PR DESCRIPTION
`opensphere` added new basemaps for EPSG:4326 that use a relative scheme. Force those to use HTTPS in Electron (they would otherwise use `file://`).