### PR TITLE
feat(electron): upgrade electron to 13.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # OpenSphere Electron Configuration
 
-Provides OpenSphere configuration specific to Electron builds. This project should be cloned alongside [`opensphere`](https://github.com/ngageoint/opensphere) and [`opensphere-electron`](https://github.com/ngageoint/opensphere-electron).
+Provides OpenSphere configuration specific to Electron builds, and the current recommended versions of `electron` and `electron-builder` dependencies. This project should be cloned alongside [`opensphere`](https://github.com/ngageoint/opensphere) and [`opensphere-electron`](https://github.com/ngageoint/opensphere-electron).
 
-These settings are primarily intended to:
+The Electron-specific settings are intended to:
+
 * Disable the proxy: CORS has been disabled in `opensphere-electron`, so a proxy is not needed for network requests.
 * Enable mixed content: Electron can access the local file system via `file://` URL's, as well as remote resources.
 * Provide a scheme for network-path references: URL's beginning with `//` are intended to use the app's URL scheme, but for Electron that will be `file://` and break the URL.

--- a/package.json
+++ b/package.json
@@ -5,12 +5,23 @@
   "build": {
     "type": "config",
     "config": "settings.json",
-    "priority": 100000
+    "priority": 100000,
+    "electron": {
+      "packages": [
+        "electron",
+        "electron-builder"
+      ]
+    }
   },
   "repository": "https://github.com/ngageoint/opensphere-config-electron",
   "keywords": [
     "OpenSphere",
     "Electron"
   ],
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "electron": "13.1.6",
+    "electron-builder": "22.11.8",
+    "opensphere": "0.0.0-development"
+  }
 }


### PR DESCRIPTION
Specifies the recommended versions of `electron` and `electron-builder`. Minimum supported versions are specified in `opensphere-electron` (ngageoint/opensphere-electron/pull/42).